### PR TITLE
Adapt to Plane.msg of object_detector_msgs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED
     geometry_msgs
     vision_msgs
     tmc_placement_area_detector
-    table_plane_extractor
+    object_detector_msgs
 )
 
 ## Generate messages in the 'msg' folder
@@ -41,7 +41,7 @@ generate_messages(
   geometry_msgs
   vision_msgs
   tmc_placement_area_detector
-  table_plane_extractor
+  object_detector_msgs
 )
 
 catkin_package()

--- a/action/ExecuteGrasp.action
+++ b/action/ExecuteGrasp.action
@@ -1,7 +1,7 @@
 # Define the goal
 geometry_msgs/PoseStamped[] grasp_poses
 string grasp_object_name
-table_plane_extractor/Plane[] table_plane_equations
+object_detector_msgs/Plane[] table_plane_equations
 ---
 geometry_msgs/Transform placement_surface_to_wrist # Placement surface for the object in EEF frame (hand_palm_link for sasha)
 ---

--- a/action/Place.action
+++ b/action/Place.action
@@ -1,5 +1,5 @@
 tmc_placement_area_detector/PlacementArea[] placement_areas
-table_plane_extractor/Plane[] table_plane_equations
+object_detector_msgs/Plane[] table_plane_equations
 vision_msgs/BoundingBox3DArray table_bbs
 geometry_msgs/Transform placement_surface_to_wrist # Placement surface for the object in EEF frame (hand_palm_link for sasha)
 ---

--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,7 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>action_lib_msgs</build_depend>
   <depend>action_lib</depend>
-  <build_depend>table_plane_extractor</build_depend>
+  <build_depend>object_detector_msgs</build_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
Changed package dependency from table_plane_extractor to object_detector_msgs to avoid circular dependencies.